### PR TITLE
Clean up IDisposable boilerplate in VideoPlayerControl

### DIFF
--- a/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
+++ b/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
@@ -263,8 +263,6 @@ namespace QuickViewFile.Controls
                     videoInWindowPlayer.Close();
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
                 disposedValue = true;
             }
         }
@@ -299,13 +297,6 @@ namespace QuickViewFile.Controls
         {
             return TimeSpan.FromSeconds(sliProgress.Value);
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~videoInWindowPlayerControl()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {


### PR DESCRIPTION
Clean up IDisposable boilerplate in VideoPlayerControl

Removed unused boilerplate comments regarding unmanaged resources and
large fields in `Dispose(bool disposing)`.
Also removed the commented-out finalizer as the class only uses managed
WPF controls and does not require custom unmanaged cleanup.

---
*PR created automatically by Jules for task [4244449047186252945](https://jules.google.com/task/4244449047186252945) started by @miclat97*