### PR TITLE
Refactor: Remove commented finalizer from VideoPlayerControl

### DIFF
--- a/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
+++ b/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
@@ -263,8 +263,6 @@ namespace QuickViewFile.Controls
                     videoInWindowPlayer.Close();
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
                 disposedValue = true;
             }
         }
@@ -299,13 +297,6 @@ namespace QuickViewFile.Controls
         {
             return TimeSpan.FromSeconds(sliProgress.Value);
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~videoInWindowPlayerControl()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {


### PR DESCRIPTION
Removed boilerplate `TODO` comments and the commented-out finalizer (`~videoInWindowPlayerControl()`) in `VideoPlayerControl.xaml.cs`. Confirmed that there are no unmanaged resources requiring a finalizer in this class.

---
*PR created automatically by Jules for task [14463733672136952494](https://jules.google.com/task/14463733672136952494) started by @miclat97*