### PR TITLE
feat: Add configurable Slideshow feature with animations

### DIFF
--- a/QuickViewFile/MainWindow.xaml
+++ b/QuickViewFile/MainWindow.xaml
@@ -58,6 +58,7 @@
                 <Button Content="Rotate" Name="RotateButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="RotateButton_Click" ToolTip="TIP: * can do this"/>
                 <Button Content="Full Screen" Name="FullScreenButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="FullScreenButton_Click" ToolTip="TIP: F4 can do this"/>
                 <Button Content="Settings" Name="SettingsButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="SettingsButton_Click" ToolTip="Open Settings"/>
+                <Button Content="Slideshow" Name="SlideshowButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="SlideshowButton_Click" ToolTip="Start Slideshow"/>
                 <Button
                   Content="Save"
                   Name="SaveButton"
@@ -191,7 +192,13 @@
                     <Grid MouseRightButtonDown="FileContentGrid_MouseRightButtonDown"  
                           Grid.Row="0"                         
                           Name="GridFileContent" ClipToBounds="True" Grid.IsSharedSizeScope="True" IsManipulationEnabled="True" SnapsToDevicePixels="True"
-                          >
+                          RenderTransformOrigin="0.5,0.5">
+                        <Grid.RenderTransform>
+                            <TransformGroup>
+                                <ScaleTransform ScaleX="1" ScaleY="1" x:Name="FileContentScale" />
+                                <TranslateTransform X="0" Y="0" x:Name="FileContentTranslate" />
+                            </TransformGroup>
+                        </Grid.RenderTransform>
 
                         <local:VideoPlayerControl
                             x:Name="VideoMedia"

--- a/QuickViewFile/MainWindow.xaml.cs
+++ b/QuickViewFile/MainWindow.xaml.cs
@@ -194,6 +194,27 @@ namespace QuickViewFile
                 }
             }
         }
+        private SlideshowHelper? _slideshowHelper;
+        private void SlideshowButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_slideshowHelper != null)
+            {
+                _slideshowHelper.Stop();
+                _slideshowHelper = null;
+                SlideshowButton.Content = "Slideshow";
+                return;
+            }
+
+            SlideshowSettingsWindow settingsWindow = new SlideshowSettingsWindow();
+            settingsWindow.Owner = this;
+            if (settingsWindow.ShowDialog() == true)
+            {
+                // start slideshow
+                _slideshowHelper = new SlideshowHelper(this, settingsWindow.SelectedMode, settingsWindow.SlideDuration, settingsWindow.AnimDuration, settingsWindow.FadeOpacity, settingsWindow.IsFastQuality);
+                _slideshowHelper.Start();
+                SlideshowButton.Content = "Stop Slideshow";
+            }
+        }
         private enum FileOperation { None, Copy, Move }
         private FileOperation _currentOperation = FileOperation.None;
         private List<string> _clipboardFiles = new List<string>();

--- a/QuickViewFile/MainWindowNoBorder.xaml
+++ b/QuickViewFile/MainWindowNoBorder.xaml
@@ -58,6 +58,7 @@
                 <Button Content="Rotate" Name="RotateButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="RotateButton_Click" ToolTip="TIP: * can do this"/>
                 <Button Content="Exit Full Screen" Name="ExitFullScreenButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="ExitFullScreenButton_Click" ToolTip="TIP: F4 can do this"/>
                 <Button Content="Settings" Name="SettingsButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="SettingsButton_Click" ToolTip="Open Settings"/>
+                <Button Content="Slideshow" Name="SlideshowButton" Height="24" Margin="0,8,10,8" Padding="10,0" Click="SlideshowButton_Click" ToolTip="Start Slideshow"/>
 
             <Button Content="Save" Name="SaveButton" Height="24" Margin="0,8,10,8" Padding="15,0" Click="SaveButton_Click" Visibility="{Binding SelectedItem.FileContentModel.ShowTextBox, Converter={StaticResource BoolToVisibilityConverter}}"/>
             </StackPanel>
@@ -185,7 +186,13 @@
                     <Grid MouseRightButtonDown="FileContentGrid_MouseRightButtonDown"  
                           Grid.Row="0"                         
                           Name="GridFileContent" ClipToBounds="True" Grid.IsSharedSizeScope="True" IsManipulationEnabled="True" SnapsToDevicePixels="True"
-                          >
+                          RenderTransformOrigin="0.5,0.5">
+                        <Grid.RenderTransform>
+                            <TransformGroup>
+                                <ScaleTransform ScaleX="1" ScaleY="1" x:Name="FileContentScale" />
+                                <TranslateTransform X="0" Y="0" x:Name="FileContentTranslate" />
+                            </TransformGroup>
+                        </Grid.RenderTransform>
 
                         <ContentControl
                             x:Name="VideoMediaNoBorder"

--- a/QuickViewFile/MainWindowNoBorder.xaml.cs
+++ b/QuickViewFile/MainWindowNoBorder.xaml.cs
@@ -195,6 +195,27 @@ namespace QuickViewFile
                 }
             }
         }
+        private SlideshowHelper? _slideshowHelper;
+        private void SlideshowButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_slideshowHelper != null)
+            {
+                _slideshowHelper.Stop();
+                _slideshowHelper = null;
+                SlideshowButton.Content = "Slideshow";
+                return;
+            }
+
+            SlideshowSettingsWindow settingsWindow = new SlideshowSettingsWindow();
+            settingsWindow.Owner = this;
+            if (settingsWindow.ShowDialog() == true)
+            {
+                // start slideshow
+                _slideshowHelper = new SlideshowHelper(this, settingsWindow.SelectedMode, settingsWindow.SlideDuration, settingsWindow.AnimDuration, settingsWindow.FadeOpacity, settingsWindow.IsFastQuality);
+                _slideshowHelper.Start();
+                SlideshowButton.Content = "Stop Slideshow";
+            }
+        }
         private enum FileOperation { None, Copy, Move }
         private FileOperation _currentOperation = FileOperation.None;
         private List<string> _clipboardFiles = new List<string>();

--- a/QuickViewFile/SlideshowHelper.cs
+++ b/QuickViewFile/SlideshowHelper.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+using System.Windows.Media.Animation;
+using QuickViewFile.ViewModel;
+
+namespace QuickViewFile
+{
+    public class SlideshowHelper
+    {
+        private Window _window;
+        private string _mode;
+        private double _slideDuration;
+        private double _animDuration;
+        private bool _fadeOpacity;
+        private bool _fastQuality;
+        private DispatcherTimer _timer;
+        private Random _random = new Random();
+
+        public SlideshowHelper(Window window, string mode, double slideDuration, double animDuration, bool fadeOpacity, bool fastQuality)
+        {
+            _window = window;
+            _mode = mode;
+            _slideDuration = slideDuration;
+            _animDuration = animDuration;
+            _fadeOpacity = fadeOpacity;
+            _fastQuality = fastQuality;
+
+            _timer = new DispatcherTimer();
+            _timer.Interval = TimeSpan.FromSeconds(_slideDuration);
+            _timer.Tick += Timer_Tick;
+        }
+
+        public void Start()
+        {
+            ResetTransforms();
+            _timer.Start();
+            AnimateCurrent();
+        }
+
+        public void Stop()
+        {
+            _timer.Stop();
+            ResetTransforms();
+        }
+
+        private void ResetTransforms()
+        {
+            if (_window is MainWindow mw)
+            {
+                mw.FileContentScale.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleXProperty, null);
+                mw.FileContentScale.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleYProperty, null);
+                mw.FileContentTranslate.BeginAnimation(System.Windows.Media.TranslateTransform.XProperty, null);
+                mw.GridFileContent.BeginAnimation(UIElement.OpacityProperty, null);
+
+                mw.FileContentScale.ScaleX = 1;
+                mw.FileContentScale.ScaleY = 1;
+                mw.FileContentTranslate.X = 0;
+                mw.FileContentTranslate.Y = 0;
+                mw.GridFileContent.Opacity = 1;
+            }
+            else if (_window is MainWindowNoBorder mwnb)
+            {
+                mwnb.FileContentScale.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleXProperty, null);
+                mwnb.FileContentScale.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleYProperty, null);
+                mwnb.FileContentTranslate.BeginAnimation(System.Windows.Media.TranslateTransform.XProperty, null);
+                mwnb.GridFileContent.BeginAnimation(UIElement.OpacityProperty, null);
+
+                mwnb.FileContentScale.ScaleX = 1;
+                mwnb.FileContentScale.ScaleY = 1;
+                mwnb.FileContentTranslate.X = 0;
+                mwnb.FileContentTranslate.Y = 0;
+                mwnb.GridFileContent.Opacity = 1;
+            }
+        }
+
+        private void Timer_Tick(object sender, EventArgs e)
+        {
+            // Move to next file
+            if (_window.DataContext is FilesListViewModel vm)
+            {
+                if (vm.ActiveListItems.Count == 0) return;
+
+                if (vm.SelectedItem == null)
+                {
+                    vm.SelectedItem = vm.ActiveListItems[0];
+                }
+                else
+                {
+                    int currentIndex = vm.ActiveListItems.IndexOf(vm.SelectedItem);
+                    int nextIndex = currentIndex + 1;
+
+                    // loop
+                    if (nextIndex >= vm.ActiveListItems.Count)
+                    {
+                        nextIndex = 0;
+                    }
+
+                    vm.SelectedItem = vm.ActiveListItems[nextIndex];
+                }
+
+                if (_window is MainWindow mw)
+                {
+                    mw.FilesListView.ScrollIntoView(vm.SelectedItem);
+                }
+                else if (_window is MainWindowNoBorder mwnb)
+                {
+                    mwnb.FilesListView.ScrollIntoView(vm.SelectedItem);
+                }
+
+                AnimateCurrent();
+            }
+        }
+
+        private void AnimateCurrent()
+        {
+            if (_mode == "None") return;
+
+            string currentMode = _mode;
+            if (currentMode == "Fade in/out and Random")
+            {
+                string[] modes = { "Slide (Right to Left)", "Center" };
+                currentMode = modes[_random.Next(modes.Length)];
+            }
+
+            UIElement? gridFileContent = null;
+            System.Windows.Media.ScaleTransform? scaleTransform = null;
+            System.Windows.Media.TranslateTransform? translateTransform = null;
+
+            if (_window is MainWindow mw)
+            {
+                gridFileContent = mw.GridFileContent;
+                scaleTransform = mw.FileContentScale;
+                translateTransform = mw.FileContentTranslate;
+            }
+            else if (_window is MainWindowNoBorder mwnb)
+            {
+                gridFileContent = mwnb.GridFileContent;
+                scaleTransform = mwnb.FileContentScale;
+                translateTransform = mwnb.FileContentTranslate;
+            }
+
+            if (gridFileContent == null || scaleTransform == null || translateTransform == null) return;
+
+            if (_fadeOpacity)
+            {
+                DoubleAnimation opacityAnim = new DoubleAnimation(0.0, 1.0, TimeSpan.FromSeconds(_animDuration));
+                gridFileContent.BeginAnimation(UIElement.OpacityProperty, opacityAnim);
+            }
+            else
+            {
+                gridFileContent.Opacity = 1.0;
+                gridFileContent.BeginAnimation(UIElement.OpacityProperty, null);
+            }
+
+            if (currentMode == "Center")
+            {
+                DoubleAnimation scaleAnim = new DoubleAnimation(0.5, 1.0, TimeSpan.FromSeconds(_animDuration));
+                scaleTransform.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleXProperty, scaleAnim);
+                scaleTransform.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleYProperty, scaleAnim);
+
+                // clear translate
+                translateTransform.BeginAnimation(System.Windows.Media.TranslateTransform.XProperty, null);
+                translateTransform.X = 0;
+            }
+            else if (currentMode == "Slide (Right to Left)")
+            {
+                double startX = _window.ActualWidth;
+                DoubleAnimation translateAnim = new DoubleAnimation(startX, 0, TimeSpan.FromSeconds(_animDuration));
+
+                // Ease if not fast
+                if (!_fastQuality) {
+                    translateAnim.EasingFunction = new System.Windows.Media.Animation.CubicEase { EasingMode = System.Windows.Media.Animation.EasingMode.EaseOut };
+                }
+
+                translateTransform.BeginAnimation(System.Windows.Media.TranslateTransform.XProperty, translateAnim);
+
+                // clear scale
+                scaleTransform.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleXProperty, null);
+                scaleTransform.BeginAnimation(System.Windows.Media.ScaleTransform.ScaleYProperty, null);
+                scaleTransform.ScaleX = 1;
+                scaleTransform.ScaleY = 1;
+            }
+        }
+    }
+}

--- a/QuickViewFile/SlideshowSettingsWindow.xaml
+++ b/QuickViewFile/SlideshowSettingsWindow.xaml
@@ -1,0 +1,54 @@
+<Window x:Class="QuickViewFile.SlideshowSettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Slideshow Settings" Height="350" Width="420" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,15">
+            <TextBlock Text="Animation Mode:" Width="170" VerticalAlignment="Center"/>
+            <ComboBox x:Name="ModeComboBox" Width="190">
+                <ComboBoxItem Content="Fade in/out and Random" IsSelected="True"/>
+                <ComboBoxItem Content="None"/>
+                <ComboBoxItem Content="Slide (Right to Left)"/>
+                <ComboBoxItem Content="Center"/>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,15">
+            <TextBlock Text="Slide Duration (seconds):" Width="170" VerticalAlignment="Center"/>
+            <TextBox x:Name="SlideDurationTextBox" Width="190" Text="5" VerticalContentAlignment="Center"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,15">
+            <TextBlock Text="Animation Duration (s):" Width="170" VerticalAlignment="Center"/>
+            <TextBox x:Name="AnimDurationTextBox" Width="190" Text="0.75" VerticalContentAlignment="Center"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,0,0,15">
+            <TextBlock Text="Fade Opacity:" Width="170" VerticalAlignment="Center"/>
+            <CheckBox x:Name="FadeOpacityCheckBox" IsChecked="True" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,0,0,15">
+            <TextBlock Text="Animation Quality:" Width="170" VerticalAlignment="Center"/>
+            <ComboBox x:Name="QualityComboBox" Width="190">
+                <ComboBoxItem Content="High (Smooth, Beautiful)" IsSelected="True"/>
+                <ComboBoxItem Content="Fast (Performance)"/>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Start" Width="80" Margin="0,0,10,0" Click="StartButton_Click"/>
+            <Button Content="Cancel" Width="80" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickViewFile/SlideshowSettingsWindow.xaml.cs
+++ b/QuickViewFile/SlideshowSettingsWindow.xaml.cs
@@ -1,0 +1,44 @@
+using System.Windows;
+
+namespace QuickViewFile
+{
+    public partial class SlideshowSettingsWindow : Window
+    {
+        public string SelectedMode { get; private set; } = "Fade in/out and Random";
+        public double SlideDuration { get; private set; } = 5.0;
+        public double AnimDuration { get; private set; } = 0.75;
+        public bool FadeOpacity { get; private set; } = true;
+        public bool IsFastQuality { get; private set; } = false;
+
+        public SlideshowSettingsWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void StartButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (ModeComboBox.SelectedItem is System.Windows.Controls.ComboBoxItem item)
+            {
+                SelectedMode = item.Content.ToString() ?? "";
+            }
+
+            if (double.TryParse(SlideDurationTextBox.Text.Replace(",", "."), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out double sd))
+                SlideDuration = sd;
+
+            if (double.TryParse(AnimDurationTextBox.Text.Replace(",", "."), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out double ad))
+                AnimDuration = ad;
+
+            FadeOpacity = FadeOpacityCheckBox.IsChecked ?? true;
+            IsFastQuality = QualityComboBox.SelectedIndex == 1;
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
Implemented the requested slideshow feature allowing users to automatically cycle through files. It includes configurable animation modes, durations, opacity fading, and performance toggles. Added a `SlideshowSettingsWindow` to configure these parameters, and `SlideshowHelper` to manage the logic independently of the window context (supports both `MainWindow` and `MainWindowNoBorder`). All required configurations are passed via UI, and animations are applied dynamically to the `GridFileContent`. Python patches were cleaned up before final commit.

---
*PR created automatically by Jules for task [11484015213321486797](https://jules.google.com/task/11484015213321486797) started by @miclat97*