### PR TITLE
Fix visual gaps, jumpy panning, touch gestures, and edge navigation

### DIFF
--- a/QuickViewFile/Controls/VideoPlayerFullScreen.xaml
+++ b/QuickViewFile/Controls/VideoPlayerFullScreen.xaml
@@ -13,7 +13,7 @@
         Title="VideoPlayerFullScreen" Height="1080" Width="1920">
     <Grid KeyDown="videoPlayer_KeyDown">
 
-        <Border Background="{DynamicResource {x:Static SystemColors.AccentColorBrushKey}}">
+        <Border Background="Transparent">
             <local:ZoomableMediaElement x:Name="videoFullScreenPlayer" Stretch="Uniform" StretchDirection="Both" LoadedBehavior="Manual"
                                          RenderOptions.BitmapScalingMode="{Binding videoQuality}"/>
         </Border>

--- a/QuickViewFile/Controls/ZoomableImage.cs
+++ b/QuickViewFile/Controls/ZoomableImage.cs
@@ -231,8 +231,8 @@ namespace QuickViewFile.Controls
             }
 
             // ...then add gesture translation
-            translateTransform.X += e.DeltaManipulation.Translation.X * currentScale;
-            translateTransform.Y += e.DeltaManipulation.Translation.Y * currentScale;
+            translateTransform.X += e.DeltaManipulation.Translation.X;
+            translateTransform.Y += e.DeltaManipulation.Translation.Y;
 
             ClampTranslation();
             e.Handled = true;

--- a/QuickViewFile/Controls/ZoomableImage.cs
+++ b/QuickViewFile/Controls/ZoomableImage.cs
@@ -132,7 +132,8 @@ namespace QuickViewFile.Controls
 
         private void Image_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            lastDragPoint = e.GetPosition(this);
+            var parent = VisualTreeHelper.GetParent(this) as UIElement;
+            lastDragPoint = e.GetPosition(parent ?? this);
             Mouse.SetCursor(Cursors.Hand);
             Mouse.OverrideCursor = Cursors.Hand;
             Mouse.UpdateCursor();
@@ -151,16 +152,9 @@ namespace QuickViewFile.Controls
         {
             if (lastDragPoint.HasValue && IsMouseCaptured)
             {
-                double multiplier;
-                if (currentScale > 4)
-                    multiplier = 4.0;
-                else if (currentScale > 1.0)
-                    multiplier = Math.Round(currentScale, 1);
-                else
-                    multiplier = 1.0;
-
-                Point currentPoint = e.GetPosition(this);
-                Vector delta = Point.Subtract(currentPoint, lastDragPoint.Value) * multiplier;
+                var parent = VisualTreeHelper.GetParent(this) as UIElement;
+                Point currentPoint = e.GetPosition(parent ?? this);
+                Vector delta = Point.Subtract(currentPoint, lastDragPoint.Value);
 
                 translateTransform.X += delta.X;
                 translateTransform.Y += delta.Y;
@@ -214,30 +208,31 @@ namespace QuickViewFile.Controls
             if (newScale < _config.MinScale) newScale = _config.MinScale;
             if (newScale > _config.MaxScale) newScale = _config.MaxScale;
 
-            if (Math.Abs(newScale - currentScale) < 0.001) return;
+            if (Math.Abs(newScale - currentScale) >= 0.001)
+            {
+                Point center = e.ManipulationOrigin;
 
-            Point center = e.ManipulationOrigin;
+                // Position relative to center of control
+                Point relativeCenter = new Point(
+                    center.X - (ActualWidth / 2),
+                    center.Y - (ActualHeight / 2));
 
-            // Position relative to center of control
-            Point relativeCenter = new Point(
-                center.X - (ActualWidth / 2),
-                center.Y - (ActualHeight / 2));
+                double oldTranslateX = translateTransform.X;
+                double oldTranslateY = translateTransform.Y;
+                double oldScale = currentScale;
 
-            double oldTranslateX = translateTransform.X;
-            double oldTranslateY = translateTransform.Y;
-            double oldScale = currentScale;
+                currentScale = newScale;
+                scaleTransform.ScaleX = newScale;
+                scaleTransform.ScaleY = newScale;
 
-            currentScale = newScale;
-            scaleTransform.ScaleX = newScale;
-            scaleTransform.ScaleY = newScale;
-
-            // Apply zoom...
-            translateTransform.X = relativeCenter.X - (relativeCenter.X - oldTranslateX) * (newScale / oldScale);
-            translateTransform.Y = relativeCenter.Y - (relativeCenter.Y - oldTranslateY) * (newScale / oldScale);
+                // Apply zoom...
+                translateTransform.X = relativeCenter.X - (relativeCenter.X - oldTranslateX) * (newScale / oldScale);
+                translateTransform.Y = relativeCenter.Y - (relativeCenter.Y - oldTranslateY) * (newScale / oldScale);
+            }
 
             // ...then add gesture translation
-            translateTransform.X += e.DeltaManipulation.Translation.X;
-            translateTransform.Y += e.DeltaManipulation.Translation.Y;
+            translateTransform.X += e.DeltaManipulation.Translation.X * currentScale;
+            translateTransform.Y += e.DeltaManipulation.Translation.Y * currentScale;
 
             ClampTranslation();
             e.Handled = true;

--- a/QuickViewFile/Controls/ZoomableMediaElement.cs
+++ b/QuickViewFile/Controls/ZoomableMediaElement.cs
@@ -107,7 +107,8 @@ namespace QuickViewFile.Controls
 
         private void Image_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            lastDragPoint = e.GetPosition(this);
+            var parent = VisualTreeHelper.GetParent(this) as UIElement;
+            lastDragPoint = e.GetPosition(parent ?? this);
             Mouse.SetCursor(Cursors.Hand);
             Mouse.OverrideCursor = Cursors.Hand;
             Mouse.UpdateCursor();
@@ -126,16 +127,9 @@ namespace QuickViewFile.Controls
         {
             if (lastDragPoint.HasValue && IsMouseCaptured)
             {
-                double multiplier;
-                if (currentScale > 4)
-                    multiplier = 4.0;
-                else if (currentScale > 1.0)
-                    multiplier = Math.Round(currentScale, 1);
-                else
-                    multiplier = 1.0;
-
-                Point currentPoint = e.GetPosition(this);
-                Vector delta = Point.Subtract(currentPoint, lastDragPoint.Value) * multiplier;
+                var parent = VisualTreeHelper.GetParent(this) as UIElement;
+                Point currentPoint = e.GetPosition(parent ?? this);
+                Vector delta = Point.Subtract(currentPoint, lastDragPoint.Value);
 
                 translateTransform.X += delta.X;
                 translateTransform.Y += delta.Y;
@@ -189,30 +183,31 @@ namespace QuickViewFile.Controls
             if (newScale < _config.MinScale) newScale = _config.MinScale;
             if (newScale > _config.MaxScale) newScale = _config.MaxScale;
 
-            if (Math.Abs(newScale - currentScale) < 0.001) return;
+            if (Math.Abs(newScale - currentScale) >= 0.001)
+            {
+                Point center = e.ManipulationOrigin;
 
-            Point center = e.ManipulationOrigin;
+                // Position relative to center of control
+                Point relativeCenter = new Point(
+                    center.X - (ActualWidth / 2),
+                    center.Y - (ActualHeight / 2));
 
-            // Position relative to center of control
-            Point relativeCenter = new Point(
-                center.X - (ActualWidth / 2),
-                center.Y - (ActualHeight / 2));
+                double oldTranslateX = translateTransform.X;
+                double oldTranslateY = translateTransform.Y;
+                double oldScale = currentScale;
 
-            double oldTranslateX = translateTransform.X;
-            double oldTranslateY = translateTransform.Y;
-            double oldScale = currentScale;
+                currentScale = newScale;
+                scaleTransform.ScaleX = newScale;
+                scaleTransform.ScaleY = newScale;
 
-            currentScale = newScale;
-            scaleTransform.ScaleX = newScale;
-            scaleTransform.ScaleY = newScale;
-
-            // Apply zoom...
-            translateTransform.X = relativeCenter.X - (relativeCenter.X - oldTranslateX) * (newScale / oldScale);
-            translateTransform.Y = relativeCenter.Y - (relativeCenter.Y - oldTranslateY) * (newScale / oldScale);
+                // Apply zoom...
+                translateTransform.X = relativeCenter.X - (relativeCenter.X - oldTranslateX) * (newScale / oldScale);
+                translateTransform.Y = relativeCenter.Y - (relativeCenter.Y - oldTranslateY) * (newScale / oldScale);
+            }
 
             // ...then add gesture translation
-            translateTransform.X += e.DeltaManipulation.Translation.X;
-            translateTransform.Y += e.DeltaManipulation.Translation.Y;
+            translateTransform.X += e.DeltaManipulation.Translation.X * currentScale;
+            translateTransform.Y += e.DeltaManipulation.Translation.Y * currentScale;
 
             ClampTranslation();
             e.Handled = true;

--- a/QuickViewFile/Controls/ZoomableMediaElement.cs
+++ b/QuickViewFile/Controls/ZoomableMediaElement.cs
@@ -206,8 +206,8 @@ namespace QuickViewFile.Controls
             }
 
             // ...then add gesture translation
-            translateTransform.X += e.DeltaManipulation.Translation.X * currentScale;
-            translateTransform.Y += e.DeltaManipulation.Translation.Y * currentScale;
+            translateTransform.X += e.DeltaManipulation.Translation.X;
+            translateTransform.Y += e.DeltaManipulation.Translation.Y;
 
             ClampTranslation();
             e.Handled = true;

--- a/QuickViewFile/MainWindow.xaml
+++ b/QuickViewFile/MainWindow.xaml
@@ -10,6 +10,7 @@
         mc:Ignorable="d"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
+        MouseLeftButtonDown="Window_MouseLeftButtonDown"
         ResizeMode="CanResize"
         KeyDown="AppWindow_KeyDown"
         Title="QuickViewFile" Height="720" Width="1280">
@@ -193,7 +194,6 @@
 
                     <!-- File content: Image, Video or Text-->
                     <Grid MouseRightButtonDown="FileContentGrid_MouseRightButtonDown"  
-                          MouseLeftButtonDown="Window_MouseLeftButtonDown"
                           ManipulationCompleted="GridFileContent_ManipulationCompleted"
                           Grid.Row="0"                         
                           Name="GridFileContent" ClipToBounds="True" Grid.IsSharedSizeScope="True" IsManipulationEnabled="True" SnapsToDevicePixels="True"

--- a/QuickViewFile/MainWindow.xaml
+++ b/QuickViewFile/MainWindow.xaml
@@ -10,7 +10,6 @@
         mc:Ignorable="d"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
-        MouseLeftButtonDown="Window_MouseLeftButtonDown"
         ResizeMode="CanResize"
         KeyDown="AppWindow_KeyDown"
         Title="QuickViewFile" Height="720" Width="1280">
@@ -181,8 +180,8 @@
                       HorizontalContentAlignment="Center" Focusable="False"/>
             <Border x:Name="ContentBorder"
                     Grid.Column="2"
-                    BorderThickness="1"
-                    Margin="1">
+                    BorderThickness="0"
+                    Margin="0">
                 <Grid
                   MouseRightButtonDown="Grid_MouseRightButtonDown"
                   Height="Auto"
@@ -194,6 +193,8 @@
 
                     <!-- File content: Image, Video or Text-->
                     <Grid MouseRightButtonDown="FileContentGrid_MouseRightButtonDown"  
+                          MouseLeftButtonDown="Window_MouseLeftButtonDown"
+                          ManipulationCompleted="GridFileContent_ManipulationCompleted"
                           Grid.Row="0"                         
                           Name="GridFileContent" ClipToBounds="True" Grid.IsSharedSizeScope="True" IsManipulationEnabled="True" SnapsToDevicePixels="True"
                           RenderTransformOrigin="0.5,0.5">

--- a/QuickViewFile/MainWindow.xaml.cs
+++ b/QuickViewFile/MainWindow.xaml.cs
@@ -774,23 +774,75 @@ namespace QuickViewFile
             {
                 if (DataContext is FilesListViewModel vm)
                 {
-                    Point mousePosition = e.GetPosition(GridFileContent);
+                    bool goPrevious = false;
+                    bool goNext = false;
 
-                    double previousItem = GridFileContent.ActualWidth * 0.08;
-                    double nextItem = GridFileContent.ActualWidth * 0.92;
+                    Point pApp = e.GetPosition(GridFileContent);
+                    double wApp = GridFileContent.ActualWidth;
 
-                    int nextFileIndex = FilesListView.SelectedIndex + 1;
-                    int previousFileIndex = FilesListView.SelectedIndex - 1;
+                    if (wApp > 0)
+                    {
+                        if (pApp.X < wApp * 0.15) goPrevious = true;
+                        else if (pApp.X > wApp * 0.85) goNext = true;
+                    }
 
-                    if (mousePosition.X < previousItem)
+                    if (!goPrevious && !goNext && ZoomableImageElement.Visibility == Visibility.Visible && ZoomableImageElement.Source != null)
+                    {
+                        var image = ZoomableImageElement;
+                        double imageWidth = image.Source.Width;
+                        double imageHeight = image.Source.Height;
+                        double controlWidth = image.ActualWidth;
+                        double controlHeight = image.ActualHeight;
+
+                        double scaleX = controlWidth / imageWidth;
+                        double scaleY = controlHeight / imageHeight;
+                        double scale = Math.Min(scaleX, scaleY);
+
+                        double drawnWidth = imageWidth * scale;
+                        double offsetX = (controlWidth - drawnWidth) / 2;
+
+                        Point pImg = e.GetPosition(image);
+
+                        if (pImg.X >= offsetX && pImg.X <= offsetX + drawnWidth)
+                        {
+                            double relativeX = pImg.X - offsetX;
+                            if (relativeX < drawnWidth * 0.15) goPrevious = true;
+                            else if (relativeX > drawnWidth * 0.85) goNext = true;
+                        }
+                    }
+
+                    if (!goPrevious && !goNext && VideoMedia.Visibility == Visibility.Visible && VideoMedia.videoInWindowPlayer.NaturalVideoWidth > 0)
+                    {
+                        double videoWidth = VideoMedia.videoInWindowPlayer.NaturalVideoWidth;
+                        double videoHeight = VideoMedia.videoInWindowPlayer.NaturalVideoHeight;
+                        double controlWidth = VideoMedia.videoInWindowPlayer.ActualWidth;
+                        double controlHeight = VideoMedia.videoInWindowPlayer.ActualHeight;
+
+                        double scaleX = controlWidth / videoWidth;
+                        double scaleY = controlHeight / videoHeight;
+                        double scale = Math.Min(scaleX, scaleY);
+
+                        double drawnWidth = videoWidth * scale;
+                        double offsetX = (controlWidth - drawnWidth) / 2;
+
+                        Point pVid = e.GetPosition(VideoMedia.videoInWindowPlayer);
+
+                        if (pVid.X >= offsetX && pVid.X <= offsetX + drawnWidth)
+                        {
+                            double relativeX = pVid.X - offsetX;
+                            if (relativeX < drawnWidth * 0.15) goPrevious = true;
+                            else if (relativeX > drawnWidth * 0.85) goNext = true;
+                        }
+                    }
+
+                    if (goPrevious)
                     {
                         FilesListView.SelectedIndex--;
                         System.Windows.Input.Mouse.SetCursor(System.Windows.Input.Cursors.None);
                         System.Windows.Input.Mouse.OverrideCursor = null;
                         System.Windows.Input.Mouse.UpdateCursor();
                     }
-
-                    if (mousePosition.X > nextItem)
+                    else if (goNext)
                     {
                         FilesListView.SelectedIndex++;
                         System.Windows.Input.Mouse.SetCursor(System.Windows.Input.Cursors.None);
@@ -810,6 +862,45 @@ namespace QuickViewFile
             catch (Exception)
             {
 
+            }
+        }
+
+        private void GridFileContent_ManipulationCompleted(object sender, ManipulationCompletedEventArgs e)
+        {
+            if (DataContext is FilesListViewModel vm)
+            {
+                // Only act if user is not currently zoomed in
+                if (ZoomableImageElement.Visibility == Visibility.Visible && ZoomableImageElement.RenderTransform is TransformGroup group)
+                {
+                    var scaleTransform = group.Children.OfType<ScaleTransform>().FirstOrDefault();
+                    if (scaleTransform != null && scaleTransform.ScaleX > 1.05) return;
+                }
+
+                if (VideoMedia.Visibility == Visibility.Visible && VideoMedia.videoInWindowPlayer.RenderTransform is TransformGroup vGroup)
+                {
+                    var scaleTransform = vGroup.Children.OfType<ScaleTransform>().FirstOrDefault();
+                    if (scaleTransform != null && scaleTransform.ScaleX > 1.05) return;
+                }
+
+                double totalX = e.TotalManipulation.Translation.X;
+                if (Math.Abs(totalX) > 100) // swipe threshold
+                {
+                    if (totalX > 0)
+                    {
+                        FilesListView.SelectedIndex--; // swipe right = previous
+                    }
+                    else
+                    {
+                        FilesListView.SelectedIndex++; // swipe left = next
+                    }
+
+                    if (FilesListView.SelectedIndex < 0) FilesListView.SelectedIndex = 0;
+                    if (FilesListView.SelectedIndex >= FilesListView.Items.Count) FilesListView.SelectedIndex = FilesListView.Items.Count - 1;
+
+                    FilesListView.ScrollIntoView(FilesListView.SelectedItem);
+                    if (FilesListView.SelectedItem is ItemList sel) vm.SelectedItem = sel;
+                    e.Handled = true;
+                }
             }
         }
 

--- a/QuickViewFile/MainWindowNoBorder.xaml
+++ b/QuickViewFile/MainWindowNoBorder.xaml
@@ -175,8 +175,8 @@
                       HorizontalContentAlignment="Center" Focusable="False"/>
             <Border x:Name="ContentBorder"
                     Grid.Column="2"
-                    BorderThickness="1"
-                    Margin="1">
+                    BorderThickness="0"
+                    Margin="0">
                 <Grid
                   MouseRightButtonDown="Grid_MouseRightButtonDown"
                   Height="Auto"
@@ -188,6 +188,7 @@
 
                     <!-- File content: Image, Video or Text-->
                     <Grid MouseRightButtonDown="FileContentGrid_MouseRightButtonDown"  
+                          ManipulationCompleted="GridFileContent_ManipulationCompleted"
                           Grid.Row="0"                         
                           Name="GridFileContent" ClipToBounds="True" Grid.IsSharedSizeScope="True" IsManipulationEnabled="True" SnapsToDevicePixels="True"
                           RenderTransformOrigin="0.5,0.5">

--- a/QuickViewFile/MainWindowNoBorder.xaml.cs
+++ b/QuickViewFile/MainWindowNoBorder.xaml.cs
@@ -693,6 +693,34 @@ namespace QuickViewFile
                         }
                     }
 
+                    // ContentControl cast check for video element handling
+                    if (!goPrevious && !goNext && VideoMediaNoBorder.Visibility == Visibility.Visible)
+                    {
+                        if (VideoMediaNoBorder.Content is Controls.VideoPlayerControl videoControl && videoControl.videoInWindowPlayer.NaturalVideoWidth > 0)
+                        {
+                            double videoWidth = videoControl.videoInWindowPlayer.NaturalVideoWidth;
+                            double videoHeight = videoControl.videoInWindowPlayer.NaturalVideoHeight;
+                            double controlWidth = videoControl.videoInWindowPlayer.ActualWidth;
+                            double controlHeight = videoControl.videoInWindowPlayer.ActualHeight;
+
+                            double scaleX = controlWidth / videoWidth;
+                            double scaleY = controlHeight / videoHeight;
+                            double scale = Math.Min(scaleX, scaleY);
+
+                            double drawnWidth = videoWidth * scale;
+                            double offsetX = (controlWidth - drawnWidth) / 2;
+
+                            Point pVid = e.GetPosition(videoControl.videoInWindowPlayer);
+
+                            if (pVid.X >= offsetX && pVid.X <= offsetX + drawnWidth)
+                            {
+                                double relativeX = pVid.X - offsetX;
+                                if (relativeX < drawnWidth * 0.15) goPrevious = true;
+                                else if (relativeX > drawnWidth * 0.85) goNext = true;
+                            }
+                        }
+                    }
+
                     if (goPrevious)
                     {
                         FilesListView.SelectedIndex--;
@@ -720,6 +748,45 @@ namespace QuickViewFile
             catch (Exception)
             {
 
+            }
+        }
+
+        private void GridFileContent_ManipulationCompleted(object sender, ManipulationCompletedEventArgs e)
+        {
+            if (DataContext is FilesListViewModel vm)
+            {
+                // Only act if user is not currently zoomed in
+                if (ZoomableImageElementNoBorder.Visibility == Visibility.Visible && ZoomableImageElementNoBorder.RenderTransform is TransformGroup group)
+                {
+                    var scaleTransform = group.Children.OfType<ScaleTransform>().FirstOrDefault();
+                    if (scaleTransform != null && scaleTransform.ScaleX > 1.05) return;
+                }
+
+                if (VideoMediaNoBorder.Visibility == Visibility.Visible && VideoMediaNoBorder.Content is Controls.VideoPlayerControl videoControl && videoControl.videoInWindowPlayer.RenderTransform is TransformGroup vGroup)
+                {
+                    var scaleTransform = vGroup.Children.OfType<ScaleTransform>().FirstOrDefault();
+                    if (scaleTransform != null && scaleTransform.ScaleX > 1.05) return;
+                }
+
+                double totalX = e.TotalManipulation.Translation.X;
+                if (Math.Abs(totalX) > 100) // swipe threshold
+                {
+                    if (totalX > 0)
+                    {
+                        FilesListView.SelectedIndex--; // swipe right = previous
+                    }
+                    else
+                    {
+                        FilesListView.SelectedIndex++; // swipe left = next
+                    }
+
+                    if (FilesListView.SelectedIndex < 0) FilesListView.SelectedIndex = 0;
+                    if (FilesListView.SelectedIndex >= FilesListView.Items.Count) FilesListView.SelectedIndex = FilesListView.Items.Count - 1;
+
+                    FilesListView.ScrollIntoView(FilesListView.SelectedItem);
+                    if (FilesListView.SelectedItem is ItemList sel) vm.SelectedItem = sel;
+                    e.Handled = true;
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes several visual and interaction issues in the QuickViewFile application:

1. **Visual:** Fixes a 1px border gap visible when maximizing the window by adjusting `BorderThickness` and `Margin` in `MainWindow.xaml` and `MainWindowNoBorder.xaml`, and setting `Background="Transparent"` in `VideoPlayerFullScreen.xaml`.
2. **Interaction:** Fixes jumpy mouse panning when an image or video is zoomed in by changing the reference for mouse position calculations to the parent element (`VisualTreeHelper.GetParent(this)`).
3. **Touch/Gestures:** Fixes touch panning by applying the translation calculation in `ManipulationDelta` even when the zoom factor hasn't changed. Touch translations are now accurately scaled.
4. **Touch/Gestures:** Introduces left/right swipe navigation using `ManipulationCompleted` events on `GridFileContent` to change files.
5. **Navigation:** Brings consistent "click on the 15% edges" navigation logic from `MainWindowNoBorder` over to the standard `MainWindow`.

---
*PR created automatically by Jules for task [3911429729166210096](https://jules.google.com/task/3911429729166210096) started by @miclat97*