### PR TITLE
Add configurable MaxThumbnailThreads setting

### DIFF
--- a/QuickViewFile/Helpers/ConfigHelper.cs
+++ b/QuickViewFile/Helpers/ConfigHelper.cs
@@ -53,6 +53,7 @@ namespace QuickViewFile.Helpers
                 key.SetValue(nameof(ConfigModel.ShadowOpacity), config.ShadowOpacity);
                 key.SetValue(nameof(ConfigModel.ShadowBlur), config.ShadowBlur);
                 key.SetValue(nameof(ConfigModel.Volume), config.Volume);
+                key.SetValue(nameof(ConfigModel.MaxThumbnailThreads), config.MaxThumbnailThreads);
             }
             catch (Exception ex)
             {
@@ -105,6 +106,7 @@ namespace QuickViewFile.Helpers
                     config.ShadowOpacity = double.Parse((string)key.GetValue(nameof(ConfigModel.ShadowOpacity).ToString(), config.ShadowOpacity));
                     config.ShadowBlur = double.Parse((string)key.GetValue(nameof(ConfigModel.ShadowBlur).ToString(), config.ShadowBlur));
                     config.Volume = double.Parse((string)key.GetValue(nameof(ConfigModel.Volume).ToString(), config.Volume.ToString()));
+                    config.MaxThumbnailThreads = (int)key.GetValue(nameof(ConfigModel.MaxThumbnailThreads), config.MaxThumbnailThreads);
                 }
                 catch (Exception ex)
                 {

--- a/QuickViewFile/Models/ConfigModel.cs
+++ b/QuickViewFile/Models/ConfigModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
@@ -58,5 +59,6 @@ namespace QuickViewFile.Models
         public double ShadowOpacity { get; set; } = 0;
         public double ShadowBlur { get; set; } = 0;
         public double Volume { get; set; } = 1;
+        public int MaxThumbnailThreads { get; set; } = Math.Max(1, Environment.ProcessorCount / 4);
     }
 }

--- a/QuickViewFile/Models/ConfigModel.cs
+++ b/QuickViewFile/Models/ConfigModel.cs
@@ -59,6 +59,6 @@ namespace QuickViewFile.Models
         public double ShadowOpacity { get; set; } = 0;
         public double ShadowBlur { get; set; } = 0;
         public double Volume { get; set; } = 1;
-        public int MaxThumbnailThreads { get; set; } = Math.Max(1, Environment.ProcessorCount / 4);
+        public int MaxThumbnailThreads { get; set; } = Math.Max(1, Environment.ProcessorCount / 2);
     }
 }

--- a/QuickViewFile/QuickViewFile.csproj
+++ b/QuickViewFile/QuickViewFile.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>2.3.0.0</Version>
+    <Version>2.3.1.0</Version>
     <ApplicationIcon>QuickViewFile.ico</ApplicationIcon>
     <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/QuickViewFile/SettingsWindow.xaml.cs
+++ b/QuickViewFile/SettingsWindow.xaml.cs
@@ -150,6 +150,7 @@ namespace QuickViewFile
             ConfigHelper.loadedConfig.ShadowOpacity = _config.ShadowOpacity;
             ConfigHelper.loadedConfig.ShadowBlur = _config.ShadowBlur;
             ConfigHelper.loadedConfig.Volume = _config.Volume;
+            ConfigHelper.loadedConfig.MaxThumbnailThreads = _config.MaxThumbnailThreads;
 
             DialogResult = true;
             Close();

--- a/QuickViewFile/ViewModel/FilesListViewModel.cs
+++ b/QuickViewFile/ViewModel/FilesListViewModel.cs
@@ -564,7 +564,7 @@ namespace QuickViewFile.ViewModel
             var itemsToLoad = ActiveListItems.ToList();
 
             // Limit concurrency based on CPU cores
-            int maxConcurrency = Math.Max(1, Environment.ProcessorCount / 4);
+            int maxConcurrency = Math.Max(1, ConfigHelper.loadedConfig.MaxThumbnailThreads);
             using var semaphore = new System.Threading.SemaphoreSlim(maxConcurrency);
 
             var tasks = itemsToLoad.Select(async item =>


### PR DESCRIPTION
This pull request adds a new setting, `MaxThumbnailThreads`, to the application settings. It defaults to `Math.Max(1, Environment.ProcessorCount / 4)` on the first run when not set in the registry, and then is stored in the user's `ConfigModel` in the Windows registry under `Software\QuickViewFile`.

- Added `MaxThumbnailThreads` property to `ConfigModel`
- Updated `ConfigHelper` to read/write `MaxThumbnailThreads` from the registry.
- Updated `SettingsWindow.xaml.cs` to apply this configuration value on save (the reflection loop automatically renders a textbox for `int` settings in the settings window GUI).
- Updated `FilesListViewModel.cs` to limit `SemaphoreSlim` concurrency to `Math.Max(1, ConfigHelper.loadedConfig.MaxThumbnailThreads)`.

---
*PR created automatically by Jules for task [11967034360185218572](https://jules.google.com/task/11967034360185218572) started by @miclat97*