### PR TITLE
Fix video playback slider loop, add click-to-seek, and resolve memory leaks

### DIFF
--- a/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
+++ b/QuickViewFile/Controls/VideoPlayerControl.xaml.cs
@@ -79,6 +79,8 @@ namespace QuickViewFile.Controls
         }
 
 
+        private bool _isUpdatingSlider = false;
+
         private void timer_Tick(object sender, EventArgs e)
         {
             // Check if the media source is set and has a known duration or it's live stream
@@ -86,11 +88,19 @@ namespace QuickViewFile.Controls
                 (videoInWindowPlayer.NaturalDuration.HasTimeSpan) &&
                 (!userIsDraggingSlider))
             {
-                sliProgress.Visibility = Visibility.Visible;
-                StatusBarMediaElement.Visibility = Visibility.Visible;
-                sliProgress.Minimum = 0;
-                sliProgress.Maximum = videoInWindowPlayer.NaturalDuration.TimeSpan.TotalSeconds;
-                sliProgress.Value = videoInWindowPlayer.Position.TotalSeconds;
+                _isUpdatingSlider = true;
+                try
+                {
+                    sliProgress.Visibility = Visibility.Visible;
+                    StatusBarMediaElement.Visibility = Visibility.Visible;
+                    sliProgress.Minimum = 0;
+                    sliProgress.Maximum = videoInWindowPlayer.NaturalDuration.TimeSpan.TotalSeconds;
+                    sliProgress.Value = videoInWindowPlayer.Position.TotalSeconds;
+                }
+                finally
+                {
+                    _isUpdatingSlider = false;
+                }
 
                 fullTime.Text = videoInWindowPlayer.NaturalDuration.TimeSpan.ToString(@"hh\:mm\:ss");
             }
@@ -174,7 +184,10 @@ namespace QuickViewFile.Controls
 
         private void sliProgress_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            videoInWindowPlayer.Position = TimeSpan.FromSeconds(sliProgress.Value);
+            if (!_isUpdatingSlider)
+            {
+                videoInWindowPlayer.Position = TimeSpan.FromSeconds(sliProgress.Value);
+            }
             lblProgressStatus.Text = TimeSpan.FromSeconds(sliProgress.Value).ToString(@"hh\:mm\:ss");
             fullTime.Text = TimeSpan.FromSeconds(sliProgress.Maximum).ToString(@"hh\:mm\:ss");
         }
@@ -289,6 +302,27 @@ namespace QuickViewFile.Controls
             videoInWindowPlayer.Source = null;
             videoInWindowPlayer.Source = currentTempSource;
             videoInWindowPlayer.Play();
+        }
+
+        public void SeekFromClick(double x, double totalWidth)
+        {
+            if (videoInWindowPlayer.Source != null && videoInWindowPlayer.NaturalDuration.HasTimeSpan && totalWidth > 0)
+            {
+                double percentage = Math.Max(0, Math.Min(1, x / totalWidth));
+                double targetSeconds = percentage * videoInWindowPlayer.NaturalDuration.TimeSpan.TotalSeconds;
+
+                _isUpdatingSlider = true;
+                try
+                {
+                    sliProgress.Value = targetSeconds;
+                }
+                finally
+                {
+                    _isUpdatingSlider = false;
+                }
+
+                videoInWindowPlayer.Position = TimeSpan.FromSeconds(targetSeconds);
+            }
         }
 
         public TimeSpan GetCurrentVideoPosition()

--- a/QuickViewFile/MainWindow.xaml.cs
+++ b/QuickViewFile/MainWindow.xaml.cs
@@ -21,6 +21,25 @@ namespace QuickViewFile
         private int degreesRotation = 0;
         public FilesListViewModel vm;
 
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            if (_slideshowHelper != null)
+            {
+                _slideshowHelper.Stop();
+                _slideshowHelper = null;
+            }
+
+            if (DataContext is QuickViewFile.ViewModel.FilesListViewModel vm)
+            {
+                if (vm.SelectedItem?.FileContentModel?.VideoMedia != null)
+                {
+                    vm.SelectedItem.FileContentModel.VideoMedia.Dispose();
+                }
+            }
+        }
+
         public MainWindow()
         {
             try
@@ -814,8 +833,23 @@ namespace QuickViewFile
 
                         if (wApp > 0 && pApp.X >= 0 && pApp.X <= wApp && pApp.Y >= 0 && pApp.Y <= GridFileContent.ActualHeight)
                         {
-                            if (pApp.X < wApp * 0.15) goPrevious = true;
-                            else if (pApp.X > wApp * 0.85) goNext = true;
+                            bool isVideoControlClick = false;
+
+                            // Check if the click is in the bottom area where the video timeline is located
+                            if (vm.SelectedItem?.FileContentModel?.VideoMedia != null)
+                            {
+                                if (GridFileContent.ActualHeight - pApp.Y <= 60)
+                                {
+                                    isVideoControlClick = true;
+                                    vm.SelectedItem.FileContentModel.VideoMedia.SeekFromClick(pApp.X, wApp);
+                                }
+                            }
+
+                            if (!isVideoControlClick)
+                            {
+                                if (pApp.X < wApp * 0.15) goPrevious = true;
+                                else if (pApp.X > wApp * 0.85) goNext = true;
+                            }
                         }
 
                         if (!goPrevious && !goNext && ZoomableImageElement.Visibility == Visibility.Visible && ZoomableImageElement.Source != null)

--- a/QuickViewFile/MainWindow.xaml.cs
+++ b/QuickViewFile/MainWindow.xaml.cs
@@ -877,30 +877,6 @@ namespace QuickViewFile
                             }
                         }
 
-                        if (!goPrevious && !goNext && VideoMedia.Visibility == Visibility.Visible && VideoMedia.videoInWindowPlayer.NaturalVideoWidth > 0)
-                        {
-                            double videoWidth = VideoMedia.videoInWindowPlayer.NaturalVideoWidth;
-                            double videoHeight = VideoMedia.videoInWindowPlayer.NaturalVideoHeight;
-                            double controlWidth = VideoMedia.videoInWindowPlayer.ActualWidth;
-                            double controlHeight = VideoMedia.videoInWindowPlayer.ActualHeight;
-
-                            double scaleX = controlWidth / videoWidth;
-                            double scaleY = controlHeight / videoHeight;
-                            double scale = Math.Min(scaleX, scaleY);
-
-                            double drawnWidth = videoWidth * scale;
-                            double offsetX = (controlWidth - drawnWidth) / 2;
-
-                            Point pVid = e.GetPosition(VideoMedia.videoInWindowPlayer);
-
-                            if (pVid.X >= offsetX && pVid.X <= offsetX + drawnWidth)
-                            {
-                                double relativeX = pVid.X - offsetX;
-                                if (relativeX < drawnWidth * 0.15) goPrevious = true;
-                                else if (relativeX > drawnWidth * 0.85) goNext = true;
-                            }
-                        }
-
                         if (goPrevious && FilesListView.SelectedIndex > 0)
                         {
                             FilesListView.SelectedIndex--;

--- a/QuickViewFile/MainWindowNoBorder.xaml.cs
+++ b/QuickViewFile/MainWindowNoBorder.xaml.cs
@@ -21,6 +21,25 @@ namespace QuickViewFile
         private int degreesRotation = 0;
         public FilesListViewModel vm;
 
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            if (_slideshowHelper != null)
+            {
+                _slideshowHelper.Stop();
+                _slideshowHelper = null;
+            }
+
+            if (DataContext is QuickViewFile.ViewModel.FilesListViewModel vm)
+            {
+                if (vm.SelectedItem?.FileContentModel?.VideoMedia != null)
+                {
+                    vm.SelectedItem.FileContentModel.VideoMedia.Dispose();
+                }
+            }
+        }
+
         public MainWindowNoBorder()
         {
             try
@@ -805,8 +824,23 @@ namespace QuickViewFile
 
                         if (wApp > 0 && pApp.X >= 0 && pApp.X <= wApp && pApp.Y >= 0 && pApp.Y <= GridFileContent.ActualHeight)
                         {
-                            if (pApp.X < wApp * 0.15) goPrevious = true;
-                            else if (pApp.X > wApp * 0.85) goNext = true;
+                            bool isVideoControlClick = false;
+
+                            // Check if the click is in the bottom area where the video timeline is located
+                            if (vm.SelectedItem?.FileContentModel?.VideoMedia != null)
+                            {
+                                if (GridFileContent.ActualHeight - pApp.Y <= 60)
+                                {
+                                    isVideoControlClick = true;
+                                    vm.SelectedItem.FileContentModel.VideoMedia.SeekFromClick(pApp.X, wApp);
+                                }
+                            }
+
+                            if (!isVideoControlClick)
+                            {
+                                if (pApp.X < wApp * 0.15) goPrevious = true;
+                                else if (pApp.X > wApp * 0.85) goNext = true;
+                            }
                         }
 
                         if (!goPrevious && !goNext && ZoomableImageElementNoBorder.Visibility == Visibility.Visible && ZoomableImageElementNoBorder.Source != null)

--- a/QuickViewFile/MainWindowNoBorder.xaml.cs
+++ b/QuickViewFile/MainWindowNoBorder.xaml.cs
@@ -868,34 +868,6 @@ namespace QuickViewFile
                             }
                         }
 
-                        // ContentControl cast check for video element handling
-                        if (!goPrevious && !goNext && VideoMediaNoBorder.Visibility == Visibility.Visible)
-                        {
-                            if (VideoMediaNoBorder.Content is Controls.VideoPlayerControl videoControl && videoControl.videoInWindowPlayer.NaturalVideoWidth > 0)
-                            {
-                                double videoWidth = videoControl.videoInWindowPlayer.NaturalVideoWidth;
-                                double videoHeight = videoControl.videoInWindowPlayer.NaturalVideoHeight;
-                                double controlWidth = videoControl.videoInWindowPlayer.ActualWidth;
-                                double controlHeight = videoControl.videoInWindowPlayer.ActualHeight;
-
-                                double scaleX = controlWidth / videoWidth;
-                                double scaleY = controlHeight / videoHeight;
-                                double scale = Math.Min(scaleX, scaleY);
-
-                                double drawnWidth = videoWidth * scale;
-                                double offsetX = (controlWidth - drawnWidth) / 2;
-
-                                Point pVid = e.GetPosition(videoControl.videoInWindowPlayer);
-
-                                if (pVid.X >= offsetX && pVid.X <= offsetX + drawnWidth)
-                                {
-                                    double relativeX = pVid.X - offsetX;
-                                    if (relativeX < drawnWidth * 0.15) goPrevious = true;
-                                    else if (relativeX > drawnWidth * 0.85) goNext = true;
-                                }
-                            }
-                        }
-
                         if (goPrevious && FilesListView.SelectedIndex > 0)
                         {
                             FilesListView.SelectedIndex--;


### PR DESCRIPTION
This PR addresses three key issues related to video playback and memory management:
1. **Performance Loop:** Modifies the video playback slider to use an update flag, breaking the two-way data-binding loop that forced the video to seek every tick, drastically improving playback performance.
2. **Smart Seeking:** The "Edge Click" navigation logic has been refined. Clicking the bottom 60 pixels of the app area when a video is playing will now accurately seek the video rather than skip to the previous/next file.
3. **Ghost Slideshow/Memory Leaks:** Fixes a bug where transitioning from fullscreen slideshow mode to windowed mode left the slideshow and video background task running. The `OnClosed` handlers now properly tear down the slideshow helper and dispose of `VideoMedia`.

---
*PR created automatically by Jules for task [18364436885753224661](https://jules.google.com/task/18364436885753224661) started by @miclat97*