### PR TITLE
feat: Add PDF, HTML, and Code file support with syntax highlighting and strict WebView2 security

### DIFF
--- a/QuickViewFile/MainWindow.xaml
+++ b/QuickViewFile/MainWindow.xaml
@@ -6,6 +6,8 @@
         xmlns:local="clr-namespace:QuickViewFile.Controls"
         xmlns:helpers="clr-namespace:QuickViewFile.Helpers"
         xmlns:viewmodel="clr-namespace:QuickViewFile.ViewModel"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
         d:DataContext="{d:DesignInstance Type=viewmodel:FilesListViewModel}"
         mc:Ignorable="d"
         WindowState="Maximized"
@@ -252,6 +254,20 @@
                                 />
                         </Grid>
 
+                        <wv2:WebView2 x:Name="WebViewElement"
+                                      Visibility="{Binding SelectedItem.FileContentModel.ShowWebView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch" />
+
+                        <avalonEdit:TextEditor x:Name="CodeEditorElement"
+                                               Visibility="{Binding SelectedItem.FileContentModel.ShowCodeEditor, Converter={StaticResource BoolToVisibilityConverter}}"
+                                               FontFamily="Consolas"
+                                               FontSize="{Binding Config.FontSize}"
+                                               IsReadOnly="True"
+                                               ShowLineNumbers="True"
+                                               HorizontalScrollBarVisibility="Auto"
+                                               VerticalScrollBarVisibility="Auto"
+                                               Margin="10" />
 
                         <Grid Visibility="{Binding SelectedItem.FileContentModel.ShowTextBox, Converter={StaticResource BoolToVisibilityConverter}}" x:Name="GridSearchBox">
                             <Grid.RowDefinitions>

--- a/QuickViewFile/MainWindowNoBorder.xaml
+++ b/QuickViewFile/MainWindowNoBorder.xaml
@@ -6,6 +6,8 @@
         xmlns:local="clr-namespace:QuickViewFile.Controls"
         xmlns:helpers="clr-namespace:QuickViewFile.Helpers"
         xmlns:viewmodel="clr-namespace:QuickViewFile.ViewModel"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
         d:DataContext="{d:DesignInstance Type=viewmodel:FilesListViewModel}"
         mc:Ignorable="d"
         WindowState="Maximized"
@@ -244,6 +246,20 @@
                                 />
                         </Grid>
 
+                        <wv2:WebView2 x:Name="WebViewElementNoBorder"
+                                      Visibility="{Binding SelectedItem.FileContentModel.ShowWebView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch" />
+
+                        <avalonEdit:TextEditor x:Name="CodeEditorElementNoBorder"
+                                               Visibility="{Binding SelectedItem.FileContentModel.ShowCodeEditor, Converter={StaticResource BoolToVisibilityConverter}}"
+                                               FontFamily="Consolas"
+                                               FontSize="{Binding Config.FontSize}"
+                                               IsReadOnly="True"
+                                               ShowLineNumbers="True"
+                                               HorizontalScrollBarVisibility="Auto"
+                                               VerticalScrollBarVisibility="Auto"
+                                               Margin="10" />
 
                         <Grid Visibility="{Binding SelectedItem.FileContentModel.ShowTextBox, Converter={StaticResource BoolToVisibilityConverter}}" x:Name="GridSearchBox">
                             <Grid.RowDefinitions>

--- a/QuickViewFile/Models/FileContentModel.cs
+++ b/QuickViewFile/Models/FileContentModel.cs
@@ -1,12 +1,21 @@
 ﻿using QuickViewFile.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace QuickViewFile.Models
 {
-    public class FileContentModel : IDisposable
+    public class FileContentModel : IDisposable, INotifyPropertyChanged
     {
-        public string? TextContent { get; set; } = null;
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        private string? _textContent = null;
+        public string? TextContent { get => _textContent; set { _textContent = value; OnPropertyChanged(); } }
 
         public ImageSource? ImageSource { get; set; } = null;
 
@@ -14,6 +23,14 @@ namespace QuickViewFile.Models
 
         public bool IsLoaded { get; set; } = false;
         public bool ShowTextBox { get; set; } = false;
+
+        private bool _showWebView = false;
+        public bool ShowWebView { get => _showWebView; set { _showWebView = value; OnPropertyChanged(); } }
+
+        public bool ShowCodeEditor { get; set; } = false;
+
+        private string? _webViewSource = null;
+        public string? WebViewSource { get => _webViewSource; set { _webViewSource = value; OnPropertyChanged(); } }
 
         public void Dispose()
         {
@@ -31,6 +48,9 @@ namespace QuickViewFile.Models
 
             IsLoaded = false;
             ShowTextBox = false;
+            ShowWebView = false;
+            ShowCodeEditor = false;
+            WebViewSource = null;
 
             // Suppress finalization to prevent GC from calling finalizer on disposed object.
             GC.SuppressFinalize(this);

--- a/QuickViewFile/QuickViewFile.csproj
+++ b/QuickViewFile/QuickViewFile.csproj
@@ -57,4 +57,10 @@
     <RuntimeHostConfigurationOption Include="Switch.System.Windows.Media.EnableHardwareAccelerationInRdp" Value="true" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Implemented PDF, HTML, and code file viewing functionality.

1.  **Code Viewer**: Added `AvalonEdit` integration for `.json, .java, .cs, .c, .cpp, .py` files to provide native syntax highlighting.
2.  **PDF/HTML Viewer**: Added `Microsoft.Web.WebView2` integration for `.pdf` and `.html/.htm` files.
3.  **Strict HTML Security**: 
    *   Intercepts `WebResourceRequested` inside WebView2.
    *   Completely blocks all internet requests (anything non-`file://` is rejected with 403 Forbidden).
    *   Introduced a new configuration setting `LoadAdjacentFilesToHtml` (0 = Disabled, 1 = Enabled).
    *   If Disabled (0), only the exact HTML file is allowed to load. No external CSS, JS, or images are permitted.
    *   If Enabled (1), the viewer allows local files loaded only from the exact same directory as the HTML file, or up to 1 subfolder deep. Attempting to traverse upwards (`../`) or escaping the root directory is blocked with 403 Forbidden.
4.  **Settings UI**: The new file extensions and the `LoadAdjacentFilesToHtml` setting are dynamically editable in the Settings Window.

---
*PR created automatically by Jules for task [8287540703250467516](https://jules.google.com/task/8287540703250467516) started by @miclat97*